### PR TITLE
fix: 로그아웃 API 토큰 전달 누락 문제 수정

### DIFF
--- a/src/auth/auth-api-slice.ts
+++ b/src/auth/auth-api-slice.ts
@@ -33,6 +33,11 @@ export interface RefreshTokenResponse {
   refresh?: string;
 }
 
+export interface LogoutRequest {
+  access?: string;
+  refresh?: string;
+}
+
 export interface LogoutResponse {
   success: boolean;
   message?: string;
@@ -52,10 +57,11 @@ export const authApiSlice = createApi({
       invalidatesTags: ["Auth"],
     }),
 
-    logout: builder.mutation<LogoutResponse, void>({
-      query: () => ({
+    logout: builder.mutation<LogoutResponse, LogoutRequest>({
+      query: (tokens) => ({
         url: "/users/logout/",
         method: "POST",
+        body: tokens, // access와 refresh 토큰을 body로 전달
       }),
       invalidatesTags: ["Auth"],
     }),

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -17,7 +17,9 @@ interface HeaderProps {
 const Header: React.FC<HeaderProps> = ({ onLogin, onLogout, onGoToMain }) => {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
-  const { isAuthenticated, user } = useAppSelector((state) => state.auth);
+  const { isAuthenticated, user, token, refreshToken } = useAppSelector(
+    (state) => state.auth
+  );
 
   const [logoutMutation] = useLogoutMutation();
 
@@ -34,15 +36,27 @@ const Header: React.FC<HeaderProps> = ({ onLogin, onLogout, onGoToMain }) => {
 
   const handleLogout = async () => {
     try {
-      await logoutMutation().unwrap();
+      console.log("🚪 로그아웃 시작 - 토큰 확인:", {
+        accessToken: token ? "있음" : "없음",
+        refreshToken: refreshToken ? "있음" : "없음",
+      });
+
+      const result = await logoutMutation({
+        access: token || undefined,
+        refresh: refreshToken || undefined,
+      }).unwrap();
+
+      console.log("✅ API 로그아웃 성공:", result);
     } catch (error) {
-      console.error("로그아웃 API 오류:", error);
+      console.error("❌ 로그아웃 API 오류:", error);
     }
 
     if (onLogout) {
       onLogout();
+      console.log("🔄 로컬 로그아웃 콜백 실행 완료");
     }
 
+    console.log("🎉 로그아웃 프로세스 완료");
     alert("로그아웃 되었습니다.");
   };
 


### PR DESCRIPTION
## 작업 내용
- 로그아웃 API 호출 시 access, refresh 토큰 전달하도록 수정
- 400 Bad Request 오류 해결

## 작업 브랜치
fix/logout-api-token-issue